### PR TITLE
Fix load order issue

### DIFF
--- a/lib/zeebe/client.rb
+++ b/lib/zeebe/client.rb
@@ -1,9 +1,8 @@
-
-require 'zeebe/client/proto/gateway_pb'
-require 'zeebe/client/proto/gateway_services_pb'
-require 'zeebe/client/version'
-
 module Zeebe
   module Client
   end
 end
+
+require 'zeebe/client/proto/gateway_pb'
+require 'zeebe/client/proto/gateway_services_pb'
+require 'zeebe/client/version'


### PR DESCRIPTION
# Issue
Currently (v0.9.1, ruby 2.6.5), attempting to require this gem results in an exception.

This appears to be due to the order of operations in client.rb, which attempts to load client/proto/gateway_pb first. That file in turn attempts to [set Zeebe::Client::GatewayProtocol](https://github.com/zeebe-io/zeebe-client-ruby/blob/master/lib/zeebe/client/proto/gateway_pb.rb#L159) before the Zeebe or Zeebe::Client modules exist, which raises a NameError.

# Fix
This PR reorders client.rb to ensure that the Zeebe and Zeebe::Client modules are defined prior to loading any other files.

## Notes on Chosen Approach
There are other ways to potentially resolve this issue:
- proto/gateway_pb.rb could use a nested structure like `module Zeebe; module Client; module GatewayProtocol; ... end; end; end`
- client.rb could require client/version (which uses the nested structure) before it requires client/proto/gateway_pb

I considered both of these approaches to be more brittle for possible future development than the solution ultimately submitted here.

# Steps to Reproduce
1. `gem install zeebe-client` (as given in the README)
2. `irb`
3. At irb prompt, `require 'zeebe/client'` (as given in the [demo script](https://github.com/zeebe-io/zeebe-client-ruby/blob/master/examples/demo.rb#L2))

## Expected Result
The gem should load correctly and the return value should be `true`.

## Actual Result
```
[dev] rusterholz$ gem install zeebe-client
Successfully installed zeebe-client-0.9.1
Parsing documentation for zeebe-client-0.9.1
Done installing documentation for zeebe-client after 0 seconds
1 gem installed
[dev] rusterholz$ irb
2.6.3 :001 > require 'zeebe/client'
Traceback (most recent call last):
       11: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/bin/irb:23:in `<main>'
       10: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/bin/irb:23:in `load'
        9: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        8: from (irb):1
        7: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
        6: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
        5: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
        4: from /Users/rusterholz/.rvm/gems/ruby-2.6.3/gems/zeebe-client-0.9.1/lib/zeebe/client.rb:2:in `<top (required)>'
        3: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        2: from /Users/rusterholz/.rvm/rubies/ruby-2.6.3/lib/ruby/site_ruby/2.6.0/rubygems/core_ext/kernel_require.rb:54:in `require'
        1: from /Users/rusterholz/.rvm/gems/ruby-2.6.3/gems/zeebe-client-0.9.1/lib/zeebe/client/proto/gateway_pb.rb:159:in `<top (required)>'
NameError (uninitialized constant Zeebe)
2.6.3 :002 >
```