### PR TITLE
Fix forward-compatibility in gemspec

### DIFF
--- a/zeebe-client.gemspec
+++ b/zeebe-client.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.3'
 
-  s.add_runtime_dependency 'grpc', '~> 1.32.0'
+  s.add_runtime_dependency 'grpc', '~> 1.32'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'bundler-audit', '~> 0.7.0'
-  s.add_development_dependency 'grpc-tools', '~> 1.32.0'
+  s.add_development_dependency 'grpc-tools', '~> 1.32'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
   s.add_development_dependency 'rubocop', '~> 0.81.0'


### PR DESCRIPTION
# Issue
Currently (v0.11.0), we are unable to use this gem in a service of ours that has its own dependency on a newer version of GRPC.

This appears to be due to the specificity of the dependency in zeebe-client.gemspec. In v0.11.0, the specification is for grpc `~> 1.28.0`, which is interpreted as `>= 1.28.0, < 1.29.0`. Our service already specified grpc `~> 1.32`, so bundler was unable to resolve the dependency:

```
Bundler could not find compatible versions for gem "grpc":
  In Gemfile:
    grpc (~> 1.32.0)

    zeebe-client (>= 0.11) was resolved to 0.11.0, which depends on
      grpc (~> 1.28.0)
```

# Fix
Master currently specifies `~ 1.32.0`. This PR reduces that to `~> 1.32`, which will be interpreted as `>= 1.32.0, < 2.0`, so that if/when future versions of grpc are released that [add features without breaking existing ones](https://semver.org/), zeebe-client will remain compatible with repos that use the newer version of that gem.

The development dependency on grpc-tools was also made less-specific, so that it can always match grpc's version.

## Note Re: Backporting
I considered whether this should be based on the `v0.11.0` tag instead of off of `master`. I don't think it's necessary to ship a backport of this without the other changes already on `master` (which are mostly centered around this dependency anyway). However if you would like me to rebase it on that commit I'm happy to do so! Let me know.