### PR TITLE
[v0.13.0] Support for Zeebe 0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+
+- add support for [Zeebe 0.26](https://github.com/zeebe-io/zeebe/releases/tag/0.26.0)
+
 ## 0.12.1 (December 11, 2020)
 
 - add support for [Zeebe 0.25.3](https://github.com/zeebe-io/zeebe/releases/tag/0.25.3)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Install the gem:
 Run a Zeebe instance locally:
 
 ```sh
-docker run -it --rm -p 26500:26500 camunda/zeebe:0.25.3
+docker run -it --rm -p 26500:26500 camunda/zeebe:0.26.0
 ```
 
 And then try the available [demo script](examples/demo.rb).

--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,7 @@ task ci: ['zeebe:start', :default, 'zeebe:stop']
 
 desc 'Starts Zeebe Docker container'
 task 'zeebe:start' do
-  sh 'docker run -d --name zeebe --rm -p 26500:26500 camunda/zeebe:0.25.3'
+  sh 'docker run -d --name zeebe --rm -p 26500:26500 camunda/zeebe:0.26.0'
   sleep(10)
 end
 

--- a/lib/zeebe/client/proto/gateway_pb.rb
+++ b/lib/zeebe/client/proto/gateway_pb.rb
@@ -137,10 +137,15 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     add_message "gateway_protocol.Partition" do
       optional :partitionId, :int32, 1
       optional :role, :enum, 2, "gateway_protocol.Partition.PartitionBrokerRole"
+      optional :health, :enum, 3, "gateway_protocol.Partition.PartitionBrokerHealth"
     end
     add_enum "gateway_protocol.Partition.PartitionBrokerRole" do
       value :LEADER, 0
       value :FOLLOWER, 1
+    end
+    add_enum "gateway_protocol.Partition.PartitionBrokerHealth" do
+      value :HEALTHY, 0
+      value :UNHEALTHY, 1
     end
     add_message "gateway_protocol.UpdateJobRetriesRequest" do
       optional :jobKey, :int64, 1
@@ -189,6 +194,7 @@ module Zeebe::Client::GatewayProtocol
   BrokerInfo = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.BrokerInfo").msgclass
   Partition = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.Partition").msgclass
   Partition::PartitionBrokerRole = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.Partition.PartitionBrokerRole").enummodule
+  Partition::PartitionBrokerHealth = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.Partition.PartitionBrokerHealth").enummodule
   UpdateJobRetriesRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.UpdateJobRetriesRequest").msgclass
   UpdateJobRetriesResponse = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.UpdateJobRetriesResponse").msgclass
   SetVariablesRequest = ::Google::Protobuf::DescriptorPool.generated_pool.lookup("gateway_protocol.SetVariablesRequest").msgclass

--- a/lib/zeebe/client/version.rb
+++ b/lib/zeebe/client/version.rb
@@ -1,6 +1,6 @@
 
 module Zeebe
   module Client
-    VERSION = '0.12.1'.freeze
+    VERSION = '0.13.0'.freeze
   end
 end

--- a/proto/gateway.proto
+++ b/proto/gateway.proto
@@ -274,10 +274,18 @@ message Partition {
     FOLLOWER = 1;
   }
 
+  // Describes the current health of the partition
+  enum PartitionBrokerHealth {
+    HEALTHY = 0;
+    UNHEALTHY = 1;
+  }
+
   // the unique ID of this partition
   int32 partitionId = 1;
   // the role of the broker for this partition
   PartitionBrokerRole role = 2;
+  // the health of this partition
+  PartitionBrokerHealth health = 3;
 }
 
 message UpdateJobRetriesRequest {


### PR DESCRIPTION
This PR:
* Imports the newest GRPC proto definition from [Zeebe 0.26](https://zeebe.io/blog/2021/01/zeebe-operate-026-release/), to make use of the new [partition health information in the topology response](https://github.com/zeebe-io/zeebe/issues/4853).
  * Note, the README says to use the proto definition from [Zeebe's develop branch](https://raw.githubusercontent.com/zeebe-io/zeebe/develop/gateway-protocol/src/main/proto/gateway.proto), but it looks like they've already started adding some unreleased future changes to that branch. So I grabbed the proto definition from [their 0.26 tag](https://raw.githubusercontent.com/zeebe-io/zeebe/0.26.0/gateway-protocol/src/main/proto/gateway.proto) instead.
* Updates the Rakefile and README to refer to Zeebe 0.26.0.
* ❗ **Updates this gem's version to 0.13.0.** ❗
  * After merging it should be ready to immediately release (unless you want to add the current date to the CHANGELOG first).

Reasons:
* We are adding support for exposing partition health information in our own monitoring tools, and we needed zeebe-client-ruby to expose that information to us in turn.