### PR TITLE
gem: add Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         - '2.5'
         - '2.6'
         - '2.7'
+        - '3.0'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 ---
 AllCops:
-  TargetRubyVersion: '2.3'
+  TargetRubyVersion: '2.5'
   Exclude:
     - 'examples/*'
     - 'lib/zeebe/client/proto/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.1
+
+- support Ruby 3.0
+
 ## 0.13.0 (February 3, 2021)
 
 - add support for [Zeebe 0.26.0](https://github.com/zeebe-io/zeebe/releases/tag/0.26.0)

--- a/zeebe-client.gemspec
+++ b/zeebe-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_runtime_dependency 'grpc', '~> 1.32'
 


### PR DESCRIPTION
- fix Rubocop to minimally require Ruby 2.5 as we officially support only down to 2.5